### PR TITLE
Удаление бесполезных правил на roskomsvoboda.org

### DIFF
--- a/advblock/specific_hide.txt
+++ b/advblock/specific_hide.txt
@@ -1298,7 +1298,7 @@ cont.ws##.ablock_side
 matematikalegko.ru##.abs
 kidstaff.com.ua##.absk
 digger.ru##.acid
-agravery.com,babla.ru,dnews.dn.ua,dumskaya.net,filehippo.com,geekmir.ru,ifun.ru,inform-ua.info,kinda.media,klops.ru,lookmeet.tv,mmovote.ru,myshared.ru,news.pn,newsru.co.il,obsuzhday.com,primpogoda.ru,prostopleer.com,regmarkets.ru,riavrn.ru,rublacklist.net,shazoo.ru,tut.by,ukranews.com,vgolos.com.ua,vogue.ru##.ad
+agravery.com,babla.ru,dnews.dn.ua,dumskaya.net,filehippo.com,geekmir.ru,ifun.ru,inform-ua.info,kinda.media,klops.ru,lookmeet.tv,mmovote.ru,myshared.ru,news.pn,newsru.co.il,obsuzhday.com,primpogoda.ru,prostopleer.com,regmarkets.ru,riavrn.ru,shazoo.ru,tut.by,ukranews.com,vgolos.com.ua,vogue.ru##.ad
 versii.com##.ad ~ noindex
 it-here.ru##.ad-bottom-dc
 moskva.fm,piter.fm##.ad-branding-block
@@ -1678,7 +1678,6 @@ kinodroid.net##.banerp
 sexgamesbox.com##.baners
 kurer-sreda.ru##.banersline
 penzainform.ru##.bank-finam
-roskomsvoboda.org##.banmain
 nr2.ru,russian-bazaar.com##.bann
 ubr.ua##.bann-cont
 ubr.ua##.bann-wrap
@@ -4984,7 +4983,6 @@ torrentinka.me##a[href*="://torrentinka.me/gom"]
 volnorez.com.ua##a[href*="://turagent.od.ua"]
 kritka.su,rsload.net##a[href*="://u.to/"]
 dnevnienovosti.ru##a[href*="://urldirect.ru/"]
-roskomsvoboda.org##a[href*="://vpnlove.me"]
 3ys.ru,libsib.ru,mydocx.ru,studopedia.su##a[href*="a24help.ru"]
 animeonline.cc,animesure.org,games.portal.md,kino4k.in,kinofanonline.net,kinoframe.net,musictor.org,newsgsm.com,rg-mechanics.site,softbesplatno.net,texdizain.net,torrentigri.xyz,torrentza.co,windowspro.ru##a[href*="aHR0c"]
 trishurupa.ru##a[href*="abc-home.ru"]
@@ -5511,7 +5509,6 @@ x-kuzov.ru##a[href^="http://x-kuzov.ru/"][target="_blank"]
 turbobit.net##a[href^="http://yandex.turbobit.net"]
 scooter777.ru##a[href^="http://yashcher.ru"] > img
 earth-chronicles.ru##a[href^="http://youcanhappy.ru/"]
-rublacklist.net##a[href^="http://zapster.me/"]
 rutvet.ru##a[href^="https://1ra.ru"]
 system-fx.ru##a[href^="https://adamantfinance.com/"]
 kinotochka.co,kinotochka.me##a[href^="https://affiliate.rusvpn.com/click.php"]


### PR DESCRIPTION
Привет!
Я - сисадмин РосКомСвободы.

До нас дошли сообщения пользователей о том, что в `RuAdList` некоторое время назад добавили строку

```roskomsvoboda.org##a[href*="://vpnlove.me"]```

На данный момент, данное правило скрытия не несёт пользы, и, более того, наоборот всё ломает:

Во-первых, небольшое вступление: `vpnlove.me` - это проект РосКомСвободы, поэтому его появление на страницах РосКомСвободы "рекламой" в типичном смысле считать, имхо, неуместно.
Да и вообще, у нас, насколько мне известно, вообще, впринципе как сущности нету сторонних баннеров и какой-то сторонней рекламы. Все баннеры что у нас бывают - ведут на наши же проекты (включая `PrivacyAccelerator` и `DemHack`).

Во-вторых, на текущий момент, `vpnlove` даже не висит на сайте в качестве баннера: он крутится в карусели "наши проекты" (и, более того, находится там даже не на первом месте).

В итоге, из-за этого правила, его отображение в карусели ломается и, как результат, в карусели остаётся только текст описания, а картинка (которая, по совместительству, ссылка на проект) пропадает. И получается каша, т.к. из-за пропажи картики съезжает текст.

Так же, в списке удалось откопать другие неактуальные и бесполезные записи:
```
rublacklist.net##a[href^="http://zapster.me/"]
```
Как минимум, во-первых, проект `zapster.me`, не взлетел и мы его похоронили уже очень давно. И ссылки на него, соответственно, на сайте нет уже много лет.
Во-вторых, на данный момент РосКомСвобода работает на другом домене, а `rublacklist` - редиректит на него.
И от правила нет толку ещё и в этом плане.
```
<...>,rublacklist.net,<...>##.ad
```
Как уже сказано в предыдущей части комментария, домен `rublacklist` сейчас не актуален (т.к. редиректит).
Плюс, такого блока (с классом `ad`) у нас в текущем движке нет. Да и, если честно, не очень помню его наличие во времена "вордпресса".
```
roskomsvoboda.org##.banmain
```
Элементов с таким классом у нас сейчас тоже нет. Так что правило тоже бесполезное.