### PR TITLE
Исключениe: dynamic.xyz

### DIFF
--- a/advblock/first_level.txt
+++ b/advblock/first_level.txt
@@ -26,3 +26,4 @@
 @@||myvi.xyz/embed/$third-party,subdocument
 @@||nyan.pw^$third-party,script,xmlhttprequest
 @@||recheck.12go.asia/*/recheck|$third-party,xmlhttprequest
+@@||dynamic.xyz^$third-party,script,xmlhttprequest


### PR DESCRIPTION
## Background
We are an authentication platform for web 3

Customers (see error below as an example) - reported that customers with AdBlock, using the Russian filter, are not able to load our SDK.

## Error
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/239781/209023972-65785b2f-2fc6-4eb7-b1c7-6ae6c451860c.png">

## Proposal
Add dynamic.xyz to the exclusion list. 
