### PR TITLE
A:`montenegro.in-facts.info`

### DIFF
--- a/advblock/thirdparty.txt
+++ b/advblock/thirdparty.txt
@@ -1197,7 +1197,7 @@
 ||statcontent.ru^$third-party
 ||static.fortfs.com/images/bnrs/$third-party
 ||static.leadia.ru/widget/$third-party
-||static.localrent.com/widget/$third-party,domain=~localrent.pl
+||static.localrent.com/widget/$third-party,domain=~localrent.pl|~montenegro.in-facts.info
 ||static.myrentacar.com/widget/$third-party
 ||static.terrhq.ru^
 ||stavkiprognozy.ru^$third-party


### PR DESCRIPTION
Hi, @dimisa-RUAdList  can you please allowlist this domain as well. as the `localrent.com` widget is not loading on the page although it's integrated in the block post itself by the domain owner.  
![image](https://github.com/easylist/ruadlist/assets/33602691/6c9b45f4-0e42-4783-8bb5-d5079ddd40f5)
Thank you in advance,