### PR TITLE
Add giga.chat to excludes for third party sberdevices.ru

### DIFF
--- a/advblock/thirdparty.txt
+++ b/advblock/thirdparty.txt
@@ -1106,7 +1106,7 @@
 ||saturn-plus.ru/downloads/$third-party
 ||sb-money.ru^$third-party
 ||sb.google.com/safebrowsing/update
-||sberdevices.ru^$third-party,domain=~24ttl.stream|~citilink.ru|~dns-shop.ru|~eldorado.ru|~megamarket.ru|~mvideo.ru|~salutejazz.ru|~sber.ru|~technopark.ru|~visper.tech
+||sberdevices.ru^$third-party,domain=~24ttl.stream|~citilink.ru|~dns-shop.ru|~eldorado.ru|~megamarket.ru|~mvideo.ru|~salutejazz.ru|~sber.ru|~technopark.ru|~visper.tech|~giga.chat
 ||scrool.ru^$third-party
 ||sdkloc1.com^$third-party
 ||searchmeta.webhost.ru^


### PR DESCRIPTION
На новом домене Гигачата giga.chat не работает статика

На форум не смог залогиниться чтобы зарепортить